### PR TITLE
Fonts, sizes, and interlinear cleanup

### DIFF
--- a/classes/sections.lua
+++ b/classes/sections.lua
@@ -5,16 +5,16 @@ local context = require("context")
 SILE.require("packages/raiselower")
 
 local numbers = {}
-numbers["0"] = "٠"
-numbers["1"] = "١"
-numbers["2"] = "٢"
-numbers["3"] = "٣"
-numbers["4"] = "٤"
-numbers["5"] = "٥"
-numbers["6"] = "٦"
-numbers["7"] = "٧"
-numbers["8"] = "٨"
-numbers["9"] = "٩"
+numbers["0"] = "۰"
+numbers["1"] = "۱"
+numbers["2"] = "۲"
+numbers["3"] = "۳"
+numbers["4"] = "۴"
+numbers["5"] = "۵"
+numbers["6"] = "۶"
+numbers["7"] = "۷"
+numbers["8"] = "۸"
+numbers["9"] = "۹"
 
 local footnoteMark = SU.utf8charfromcodepoint('U+0602')
 
@@ -116,7 +116,7 @@ local charStyles = {
     family = "Times New Roman"
   },
   zgrk = {
-    family = "Times New Roman"
+    family = "SBL Greek"
   }
 }
 
@@ -504,7 +504,7 @@ SILE.registerCommand("note", function (options, content)
   SILE.typesetter = sections.notesTypesetter
   SILE.call("bidi-on")
   SILE.settings.temporarily(function ()
-    SILE.call("font", {size = "7pt"})
+    SILE.call("font", {size = "9pt"})
     -- SILE.settings.set("document.baselineskip", SILE.nodefactory.newVglue("5pt"))
     -- SILE.settings.set("document.lineskip", SILE.nodefactory.newVglue("30pt"))
     SILE.call("set", {
@@ -551,9 +551,10 @@ function sections:init()
   SILE.call("font", {
     -- family = "Scheherazade",
     family = "Awami Nastaliq",
-    size = "12pt",
+    size = "11pt",
     language = "urd",
-    script = "Arab"
+    script = "Arab",
+	features = "+shrt=3"
     -- direction = "RTL"
   })
   return ret

--- a/packages/build-interlinear.lua
+++ b/packages/build-interlinear.lua
@@ -1,14 +1,14 @@
 SILE.registerCommand("interlinear:vernacular-font", function(options, content)
   SILE.call("font", {
     direction = "RTL",
-    size = "9pt",
+    size = "10pt",
     weight = 400
   })
 end)
 
 SILE.registerCommand("interlinear:source-font", function(options, content)
   SILE.call("font", {
-    family = "Times New Roman",
+    family = "SBL Greek",
     size = "12pt",
     weight = 800
   })

--- a/preprocessing/create-interlinear.lua
+++ b/preprocessing/create-interlinear.lua
@@ -23,9 +23,14 @@ function buildLink (cluster, map)
   for i, lexeme in ipairs(cluster) do
     if lexeme.tag == "Lexeme" then
       id = lexeme.attr.Id
-      greek = greek..string.sub(id, string.find(id, ':') + 1, -1)
-      if string.len(vernacular) > 0 then vernacular = vernacular.." " end
-      vernacular = vernacular..(map[lexeme.attr.GlossId] or "~")
+	  if string.find(id, 'Word:') == nil
+	  then
+		return nil
+	  else
+		greek = greek..string.sub(id, string.find(id, ':') + 1, -1)
+		if string.len(vernacular) > 0 then vernacular = vernacular.." " end
+		vernacular = vernacular..(map[lexeme.attr.GlossId] or "~")
+	  end
     end
   end
   return {


### PR DESCRIPTION
The Greek font can be downloaded for free from https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx

I thought I had pushed the interlinear fix earlier, but maybe I didn't. It ignores "Stem", "Suffix" and other types of entries in the raw interlinear data and only picks up full words.