### PR TITLE
Change chapter order

### DIFF
--- a/render
+++ b/render
@@ -15,7 +15,7 @@ lua preprocess.lua $@ && cd ..
 
 echo "return {side=\"right\",page=1}" > context.lua
 
-CHAPTERS=$(ls *.xml)
+CHAPTERS=$(ls -v *.xml)
 
 echo "Rendering PDFs"
 for CHAPTER in $CHAPTERS
@@ -30,7 +30,7 @@ if [ ! -d output/$1 ]; then
 fi
 
 echo "Combining PDFs"
-PDFS=$(ls *.pdf)
+PDFS=$(ls -v *.pdf)
 gs -dNOPAUSE -sDEVICE=pdfwrite -sOUTPUTFILE=$1.pdf -dBATCH $PDFS
 
 mv *.xml output/$1


### PR DESCRIPTION
Chapters were being built and combined in pdf in the order 1, 10, 11, ..., 2, etc., instead of the natural order 1, 2, 3, ..., 10, 11, etc.